### PR TITLE
Limit ORS batch throughput to one request per minute

### DIFF
--- a/includes/Jobs/Nearby_Auto_Processor.php
+++ b/includes/Jobs/Nearby_Auto_Processor.php
@@ -32,8 +32,8 @@ class Nearby_Auto_Processor {
      */
     public function add_cron_interval($schedules) {
         $schedules['db_nearby_auto_process_interval'] = array(
-            'interval' => 30 * MINUTE_IN_SECONDS, // 30 minut
-            'display' => __('Každých 30 minut')
+            'interval' => MINUTE_IN_SECONDS, // 1 minuta
+            'display' => __('Každou minutu')
         );
         return $schedules;
     }
@@ -42,7 +42,7 @@ class Nearby_Auto_Processor {
      * Naplánovat automatické zpracování
      */
     public function schedule_auto_processing() {
-        // Spustit každých 30 minut pouze pokud je povoleno
+        // Spustit každou minutu pouze pokud je povoleno
         $auto_enabled = get_option('db_nearby_auto_enabled', false);
         if ($auto_enabled && !wp_next_scheduled('db_nearby_auto_process')) {
             wp_schedule_event(time(), 'db_nearby_auto_process_interval', 'db_nearby_auto_process');
@@ -72,7 +72,7 @@ class Nearby_Auto_Processor {
         
         // Získat doporučený batch size
         $batch_size = $this->quota_manager->get_recommended_batch_size();
-        
+
         if ($batch_size <= 0) {
             error_log("[DB Nearby Auto] Žádná kvóta k dispozici");
             return;
@@ -89,7 +89,7 @@ class Nearby_Auto_Processor {
         // Pokud jsou ještě položky ve frontě, naplánovat další běh
         $stats = $this->queue_manager->get_stats();
         if ($stats->pending > 0) {
-            $next_run = time() + (30 * MINUTE_IN_SECONDS); // Za 30 minut
+            $next_run = time() + MINUTE_IN_SECONDS; // další položka za minutu
             wp_schedule_single_event($next_run, 'db_nearby_auto_process');
         }
     }

--- a/includes/Jobs/Nearby_Batch_Processor.php
+++ b/includes/Jobs/Nearby_Batch_Processor.php
@@ -21,7 +21,7 @@ class Nearby_Batch_Processor {
     /**
      * Zpracovat dávku položek z fronty
      */
-    public function process_batch($max_items = 10) {
+    public function process_batch($max_items = 1) {
         $processed = 0;
         $errors = 0;
         
@@ -36,7 +36,7 @@ class Nearby_Batch_Processor {
         }
         
         // Získat položky k zpracování
-        $items = $this->queue_manager->get_pending_items($max_items);
+        $items = $this->queue_manager->get_pending_items(min(1, max(1, (int)$max_items)));
         
         if (empty($items)) {
             return array(

--- a/includes/Jobs/Nearby_Recompute_Job.php
+++ b/includes/Jobs/Nearby_Recompute_Job.php
@@ -54,6 +54,9 @@ class Nearby_Recompute_Job {
      */
     public function process_nearby_data($origin_id, $type, $candidates) {
         try {
+            $start_time = microtime(true);
+            $matrix_calls = 0;
+            $iso_calls = 0;
             $meta_key = ($type === 'poi') ? '_db_nearby_cache_poi_foot' : '_db_nearby_cache_charger_foot';
             
             // Načíst origin souřadnice podle typu postu
@@ -91,19 +94,36 @@ class Nearby_Recompute_Job {
             
             $items = array();
             $total = count($candidates);
-            
+            $original_total = $total;
+            $matrix_limit = max(1, API_Quota_Manager::ORS_MATRIX_MAX_LOCATIONS - 1);
+
+            if ($total > $matrix_limit) {
+                $this->debug_log('[Matrix] candidate limit enforced', [
+                    'origin_id' => $origin_id,
+                    'type' => $type,
+                    'original_total' => $original_total,
+                    'limited_to' => $matrix_limit
+                ]);
+                $candidates = array_slice($candidates, 0, $matrix_limit);
+                $total = count($candidates);
+            }
+
+            $batch_size = max(1, min($batch_size, $total));
+
             // Zpracovat po dávkách
             for ($i = 0; $i < $total; $i += $batch_size) {
                 $chunk = array_slice($candidates, $i, $batch_size);
+                $normalized_chunk = $this->normalize_matrix_candidates($chunk);
                 $chunk_index = (int) floor($i / $batch_size);
-                $chunk_result = $this->process_chunk($chunk, $orsKey, $provider, $profile, $origin_lat, $origin_lng, $origin_id, $chunk_index);
-                
+                $chunk_result = $this->process_chunk($normalized_chunk, $orsKey, $provider, $profile, $origin_lat, $origin_lng, $origin_id, $chunk_index);
+
                 if (!$chunk_result['success']) {
                     return $chunk_result;
                 }
-                
+
                 $items = array_merge($items, $chunk_result['items']);
-                
+                $matrix_calls++;
+
                 // Pauza mezi dávkami
                 if ($i + $batch_size < $total) {
                     usleep(150000); // 150ms
@@ -115,14 +135,23 @@ class Nearby_Recompute_Job {
 
             // Současně stáhnout a uložit isochrones stejně jako v recompute_nearby_for_origin
             if (!empty($orsKey) && $provider === 'ors') {
-                $this->fetch_and_cache_isochrones($origin_id, $origin_lat, $origin_lng, $orsKey);
+                if ($this->fetch_and_cache_isochrones($origin_id, $origin_lat, $origin_lng, $orsKey)) {
+                    $iso_calls++;
+                }
             }
-            
+
             // Přidat do zpracovaných míst
+            $processing_time = round(microtime(true) - $start_time, 3);
+            $api_calls_used = array('matrix' => $matrix_calls, 'isochrones' => $iso_calls);
             $this->track_processed_location($origin_id, $type, $candidates, $api_calls_used, $processing_time);
-            
-            return array('success' => true, 'items_count' => count($items));
-            
+
+            return array(
+                'success' => true,
+                'items_count' => count($items),
+                'api_calls' => $api_calls_used,
+                'processing_time_s' => $processing_time
+            );
+
         } catch (Exception $e) {
             return array('success' => false, 'error' => $e->getMessage());
         }
@@ -256,6 +285,20 @@ class Nearby_Recompute_Job {
             // 1) Kandidáti (Haversine; vyber typ protilehlý vůči originu)
             $candidates = $this->get_candidates($lat, $lng, $type, $radiusKm, $maxCand);
             $total = count($candidates);
+            $original_total = $total;
+            $matrix_limit = max(1, API_Quota_Manager::ORS_MATRIX_MAX_LOCATIONS - 1);
+
+            if ($total > $matrix_limit) {
+                $this->debug_log('[Matrix] candidate limit enforced', [
+                    'origin_id' => $origin_id,
+                    'type' => $type,
+                    'original_total' => $original_total,
+                    'limited_to' => $matrix_limit,
+                    'context' => 'recompute'
+                ]);
+                $candidates = array_slice($candidates, 0, $matrix_limit);
+                $total = count($candidates);
+            }
 
             if ($total === 0) {
                 $this->write_cache($origin_id, $meta_key, [], false, 0, 0, current_time('c'), null);
@@ -265,6 +308,7 @@ class Nearby_Recompute_Job {
             // 2) ORS Matrix po batších
             $items = [];
             $done  = 0;
+            $batchSize = max(1, min($batchSize, $total));
 
             for ($i=0; $i<$total; $i += $batchSize) {
                 $chunk = array_slice($candidates, $i, $batchSize);
@@ -445,8 +489,11 @@ class Nearby_Recompute_Job {
     
     /**
      * Načíst a uložit isochrones data současně s nearby data
+     *
+     * @return bool True pokud proběhl HTTP request na ORS API.
      */
     private function fetch_and_cache_isochrones($origin_id, $lat, $lng, $orsKey) {
+        $did_call = false;
         try {
             $cfg = get_option('db_nearby_config', []);
             $profile = 'foot-walking';
@@ -464,11 +511,11 @@ class Nearby_Recompute_Job {
                     $ttl_days = 30; // Default TTL
                     $computed_at = isset($payload['computed_at']) ? strtotime($payload['computed_at']) : 0;
                     if ((time() - $computed_at) < ($ttl_days * DAY_IN_SECONDS)) {
-                        return; // Data jsou ještě platná
+                        return false; // Data jsou ještě platná
                     }
                 }
             }
-            
+
             // Zkontrolovat lokální minutový limit
             $quota_manager = new \DB\Jobs\API_Quota_Manager();
             $minute_check = $quota_manager->check_minute_limit('isochrones');
@@ -480,21 +527,22 @@ class Nearby_Recompute_Job {
                     'tokens_before' => $minute_check['tokens_before'] ?? null,
                     'tokens_after' => $minute_check['tokens_after'] ?? null
                 ]);
-                return;
+                return false;
             }
-            
+
             $body = [
                 'locations' => [[(float)$lng, (float)$lat]],
                 'range' => $ranges,
                 'range_type' => 'time'
             ];
-            
+
             $this->debug_log('[Isochrones] sending request', [
                 'origin_id' => $origin_id,
                 'ranges' => $ranges,
                 'tokens_after' => $minute_check['tokens_after'] ?? null
             ]);
 
+            $did_call = true;
             $response = wp_remote_post("https://api.openrouteservice.org/v2/isochrones/{$profile}", [
                 'headers' => [
                     'Authorization' => $orsKey,
@@ -511,9 +559,9 @@ class Nearby_Recompute_Job {
                     'origin_id' => $origin_id,
                     'error' => $response->get_error_message()
                 ]);
-                return;
+                return $did_call;
             }
-            
+
             $http_code = wp_remote_retrieve_response_code($response);
             $response_body = wp_remote_retrieve_body($response);
             $data = json_decode($response_body, true);
@@ -537,18 +585,18 @@ class Nearby_Recompute_Job {
                     'http_code' => $http_code
                 ]);
                 $this->set_isochrones_error($origin_id, $profile, 'unauthorized', 'API key invalid');
-                return;
+                return $did_call;
             }
-            
+
             if ($http_code === 429) {
                 $this->debug_log('[Isochrones] rate limited', [
                     'origin_id' => $origin_id,
                     'retry_after' => $retry_after_header
                 ]);
                 $this->set_isochrones_error($origin_id, $profile, 'rate_limited', 'Rate limited');
-                return;
+                return $did_call;
             }
-            
+
             if ($http_code !== 200) {
                 $this->debug_log('[Isochrones] unexpected response', [
                     'origin_id' => $origin_id,
@@ -556,9 +604,9 @@ class Nearby_Recompute_Job {
                     'body_excerpt' => $this->truncate_body($response_body)
                 ]);
                 $this->set_isochrones_error($origin_id, $profile, 'upstream_error', "HTTP $http_code: " . ($data['error']['message'] ?? 'Unknown error'));
-                return;
+                return $did_call;
             }
-            
+
             // Úspěch - uložit data
             $payload = [
                 'version' => 1,
@@ -581,11 +629,14 @@ class Nearby_Recompute_Job {
                 'ratelimit_remaining' => $remaining_header
             ]);
 
+            return $did_call;
+
         } catch (\Throwable $e) {
             $this->debug_log('[Isochrones] exception', [
                 'origin_id' => $origin_id,
                 'error' => $e->getMessage()
             ]);
+            return $did_call;
         }
     }
     
@@ -618,6 +669,9 @@ class Nearby_Recompute_Job {
      */
     public function get_candidates($lat, $lng, $type, $radiusKm, $limit) {
         global $wpdb;
+
+        $matrix_limit = max(1, API_Quota_Manager::ORS_MATRIX_MAX_LOCATIONS - 1);
+        $limit = max(1, min((int)$limit, $matrix_limit));
 
         // type='poi' znamená hledat POI pro origin (může být charging_location nebo rv_spot)
         // type='charging_location' znamená hledat charging_location pro origin (může být poi nebo rv_spot)
@@ -712,7 +766,25 @@ class Nearby_Recompute_Job {
         $c = 2 * atan2(sqrt($a), sqrt(1-$a));
         return (int) round($earth_radius_km * $c * 1000);
     }
-    
+
+    /**
+     * Převést kandidáty na stdClass pro jednotnou práci s ORS matrix API.
+     */
+    private function normalize_matrix_candidates(array $candidates) {
+        return array_map(function($candidate) {
+            if (is_object($candidate)) {
+                return $candidate;
+            }
+
+            $object = new \stdClass();
+            foreach ($candidate as $key => $value) {
+                $object->{$key} = $value;
+            }
+
+            return $object;
+        }, $candidates);
+    }
+
     /**
      * Zpracovat dávku kandidátů
      */
@@ -857,6 +929,8 @@ class Nearby_Recompute_Job {
                 'post_type' => (string)$cand->type,
                 'duration_s' => (int)round($durations[$idx] ?? -1),
                 'distance_m' => (int)round($distances[$idx] ?? -1),
+                'walk_m' => (int)round($distances[$idx] ?? -1),
+                'secs' => (int)round($durations[$idx] ?? -1),
                 'provider' => 'ors.matrix',
                 'profile' => $profile,
             );


### PR DESCRIPTION
## Summary
- add explicit ORS quota constants and derive recommended batch size from the documented one-call-per-minute policy
- throttle the automatic queue processor and batch handler so only a single queue row (one matrix + one isochrone) is executed each minute
- enforce ORS matrix destination limits, normalise candidate payloads for single-call processing, and track the resulting API call usage per item

## Testing
- php -l includes/Jobs/API_Quota_Manager.php
- php -l includes/Jobs/Nearby_Auto_Processor.php
- php -l includes/Jobs/Nearby_Batch_Processor.php
- php -l includes/Jobs/Nearby_Recompute_Job.php

------
https://chatgpt.com/codex/tasks/task_e_68d6615c6f2c8320b931e09794e996d5