### PR TITLE
Fix ORS auto processing controls

### DIFF
--- a/includes/Jobs/Nearby_Batch_Processor.php
+++ b/includes/Jobs/Nearby_Batch_Processor.php
@@ -21,7 +21,7 @@ class Nearby_Batch_Processor {
     /**
      * Zpracovat dávku položek z fronty
      */
-    public function process_batch($max_items = 10) {
+    public function process_batch($max_items = 1) {
         $processed = 0;
         $errors = 0;
         
@@ -36,7 +36,7 @@ class Nearby_Batch_Processor {
         }
         
         // Získat položky k zpracování
-        $items = $this->queue_manager->get_pending_items($max_items);
+        $items = $this->queue_manager->get_pending_items(min(1, max(1, (int)$max_items)));
         
         if (empty($items)) {
             return array(


### PR DESCRIPTION
## Summary
- ensure the ORS auto-processing toggle updates the stored flag, schedules a run immediately, and refreshes the cron status display
- replace the old batch/test controls with a single "process 1 item" action and live queue stats updates in the admin UI
- have both manual and cron processing share the same single-item execution path with quota-aware responses and queue statistics
- enforce a single ORS matrix request per queue item while still caching isochrones so we respect the 1 matrix + 1 isochrone quota

## Testing
- php -l includes/Admin/Nearby_Queue_Admin.php
- php -l includes/Jobs/Nearby_Auto_Processor.php
- php -l includes/Jobs/Nearby_Recompute_Job.php

------
https://chatgpt.com/codex/tasks/task_e_68d6615c6f2c8320b931e09794e996d5